### PR TITLE
Support for new Tradfri LED drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin needs at least gateway version 1.2.42 !
 
 ### Installation
 
-Just activate the plugin in your pimatic config. The plugin manager automatically installs the package with his dependencys.
+Just activate the plugin in your pimatic config. The plugin manager automatically installs the package with his dependencies.
 
 ### Software dependencies
 
@@ -26,16 +26,24 @@ This plugin depends on tradfri-coapdtls.
 
 ### Configuration
 
-You can load the plugin by adding following in the config.json from your pimatic server:
+You can load the plugin by adding following in the "plugins" section in config.json from your pimatic server:
 
-You only need the security id which is backside of the gateway. At startup the plugin discovers the gateway.
+You only need the security id which is backside of the gateway (i.e. Security Code) and the gateway's IP address. At startup the plugin discovers the gateway.
+
+    {
+      "plugin": "tradfri",
+      "secID": "GATEWAY KEY",
+      "hubIP": "GATEWAY IP"
+    }
+
+Configuration after discovery.
 
     {
       "plugin": "tradfri",
       "secID": "GATEWAY KEY",
       "hubIP": "GATEWAY IP",
-      "identity": ""
-      "psk": ""
+      "identity": "",
+      "psk": "",
       "debug": true
     }
 

--- a/tradfri.coffee
+++ b/tradfri.coffee
@@ -1016,7 +1016,8 @@ module.exports = (env) ->
     parseAction: (input, context) =>
       TradfriDevices = _(@framework.deviceManager.devices).values().filter(
         (device) => _.includes [
-          'TradfriDimmerTemp'
+          'TradfriDimmerTemp',
+          'TradfriRGB'
         ], device.config.class
       ).value()
 

--- a/tradfri.coffee
+++ b/tradfri.coffee
@@ -127,6 +127,8 @@ module.exports = (env) ->
                 when device[3][1] == "FLOALT panel WS 30x90" then "TradfriDimmerTemp"
                 when device[3][1] == "FLOALT panel WS 30x30" then "TradfriDimmerTemp"
                 when device[3][1] == "FLOALT panel WS 60x60" then "TradfriDimmerTemp"
+                when device[3][1] == "TRADFRI transformer 10W" then "TradfriDimmer"
+                when device[3][1] == "TRADFRI transformer 30W" then "TradfriDimmer"
                 when device[3][1] == "TRADFRI remote control" then "TradfriActor"
                 when device[3][1] == "TRADFRI motion sensor" then "TradfriActor"
                 when device[3][1] == "TRADFRI wireless dimmer" then "TradfriActor"


### PR DESCRIPTION
IKEA released new LED drivers. These are dimmers only so the 'switch else' should've worked too. It's just to complement the existing list of Tradfri user agents. 