### PR TITLE
Support for new Tradfri LED drivers

### DIFF
--- a/tradfri.coffee
+++ b/tradfri.coffee
@@ -127,6 +127,8 @@ module.exports = (env) ->
                 when device[3][1] == "FLOALT panel WS 30x90" then "TradfriDimmerTemp"
                 when device[3][1] == "FLOALT panel WS 30x30" then "TradfriDimmerTemp"
                 when device[3][1] == "FLOALT panel WS 60x60" then "TradfriDimmerTemp"
+                when device[3][1] == "TRADFRI transformer 10W" then "TradfriDimmer"
+                when device[3][1] == "TRADFRI transformer 30W" then "TradfriDimmer"
                 when device[3][1] == "TRADFRI remote control" then "TradfriActor"
                 when device[3][1] == "TRADFRI motion sensor" then "TradfriActor"
                 when device[3][1] == "TRADFRI wireless dimmer" then "TradfriActor"


### PR DESCRIPTION
IKEA released new LED drivers. These are dimmers only so the 'switch else' should've worked too. It's just to complement the existing list of Tradfri user agents.