### PR TITLE
Fixes on set color temp action and tradriDimmerTemp::setColor method

### DIFF
--- a/tradfri.coffee
+++ b/tradfri.coffee
@@ -888,7 +888,7 @@ module.exports = (env) ->
 
 
     setColor: (color) =>
-      if @_color is color then return Promise.resolve true
+      #if @_color is color then return Promise.resolve true
       ncolor=Math.round (min + Math.abs(color-100) / 100 * (max-min))
       tcolor=Color.kelvin_to_xy(ncolor)
       ncolor=Math.round (cmin + color / 100 * (cmax-cmin))
@@ -1203,7 +1203,7 @@ module.exports = (env) ->
         if simulate
           __("would dim %s to %s%%", @device.name, value)
         else
-          @device.setColor(value).then( => __("dimmed %s to %s%%", @device.name, value) )
+          @device.setColor(value).then( => __("Set color temp of %s to %s%%", @device.name, value) )
       )
 
     executeAction: (simulate) =>


### PR DESCRIPTION
Made action logging more descriptive (Set color temp..... instead of Dimmed to....)
Removed return if current color equals requested color to fix a bug where color temp is not set under the below condition:
-Light currently is in color mode (e.g. red - #FF0000)
- @_color = 100,
setColor(100) is invoked
=> Light is not changed from color mode to colorTemp mode... @_color already has the value, therefore Promise.resolve() is returned with no action done.